### PR TITLE
Code Coverage Badges: Integration with Codecov and Coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,70 @@ jobs:
       # run tests!
       - run: npm test
 
+  codecov_report_code_coverage:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm test && npm run-script codecov
+
+  coveralls_report_code_coverage:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:7.10
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/mongo:3.4.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: npm test && npm run-script coveralls
+
   version:
     docker:
       # specify the version you desire here
@@ -95,7 +159,12 @@ workflows:
   build_tag_publish:
     jobs:
         - build
+        - coveralls_report_code_coverage:
+            requires:
+              - build
+        - codecov_report_code_coverage:
+            requires:
+              - build
         - publish:
             requires:
               - build
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # swatchjs-express
 
-[![CircleCI](https://circleci.com/gh/builtforme/swatchjs-express.svg?style=svg)](https://circleci.com/gh/builtforme/swatchjs-express) | [![Known Vulnerabilities](https://snyk.io/test/github/builtforme/swatchjs-express/badge.svg)](https://snyk.io/test/github/builtforme/swatchjs-express)
+[![CircleCI](https://circleci.com/gh/builtforme/swatchjs-express.svg?style=svg)](https://circleci.com/gh/builtforme/swatchjs-express) | [![codecov](https://codecov.io/gh/builtforme/swatchjs-express/branch/master/graph/badge.svg)](https://codecov.io/gh/builtforme/swatchjs-express) | [![Coverage Status](https://coveralls.io/repos/github/builtforme/swatchjs-express/badge.svg?branch=master)](https://coveralls.io/github/builtforme/swatchjs-express?branch=master) | [![Known Vulnerabilities](https://snyk.io/test/github/builtforme/swatchjs-express/badge.svg)](https://snyk.io/test/github/builtforme/swatchjs-express)
 
 An adapter to expose [swatchjs]() via [Express](https://www.npmjs.com/package/express).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-express",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,77 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "argv": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+      "dev": true
+    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "balanced-match": {
@@ -15,6 +82,33 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -32,10 +126,16 @@
       "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
       "dev": true
     },
+    "caseless": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+      "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+      "dev": true
+    },
     "chai": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
-      "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
+      "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
       "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
@@ -46,11 +146,121 @@
         "type-detect": "4.0.3"
       }
     },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "codecov": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.3.0.tgz",
+      "integrity": "sha1-rSWixuBELRN0DZ1N27mj4nFDMPQ=",
+      "dev": true,
+      "requires": {
+        "argv": "0.0.2",
+        "request": "2.81.0",
+        "urlgrey": "0.4.4"
+      },
+      "dependencies": {
+        "caseless": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+          "dev": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+          "dev": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.16",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
@@ -67,13 +277,66 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "debug": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-      "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "coveralls": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
+      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
       "dev": true,
       "requires": {
-        "ms": "0.7.2"
+        "js-yaml": "3.6.1",
+        "lcov-parse": "0.0.10",
+        "log-driver": "1.2.5",
+        "minimist": "1.2.0",
+        "request": "2.79.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
       }
     },
     "deep-eql": {
@@ -93,17 +356,68 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "diff": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
       "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
       "dev": true
     },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.16"
+      }
     },
     "formatio": {
       "version": "1.2.0",
@@ -120,11 +434,49 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-arguments": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/function-arguments/-/function-arguments-1.0.8.tgz",
+      "integrity": "sha1-uaAdrKa4lO/4w9NoQDde2WNqbA8=",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
     },
     "glob": {
       "version": "7.1.1",
@@ -152,11 +504,75 @@
       "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
       "dev": true
     },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+      "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "commander": "2.9.0",
+        "is-my-json-valid": "2.16.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "has-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
+    },
+    "hoek": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ==",
+      "dev": true
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -174,16 +590,146 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
+      "dev": true
+    },
+    "joi": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0",
+        "isemail": "2.2.1",
+        "items": "2.1.1",
+        "topo": "2.0.2"
+      }
+    },
+    "js-yaml": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.6.1.tgz",
+      "integrity": "sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
     "lodash._baseassign": {
@@ -254,11 +800,32 @@
         "lodash.isarray": "3.0.4"
       }
     },
+    "log-driver": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
+      "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
     "lolex": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
+    },
+    "mime-db": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.29.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -285,14 +852,14 @@
       }
     },
     "mocha": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
-      "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
-        "debug": "2.6.0",
+        "debug": "2.6.8",
         "diff": "3.2.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
@@ -304,9 +871,9 @@
       }
     },
     "ms": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
     "native-promise-only": {
@@ -316,9 +883,9 @@
       "dev": true
     },
     "nyc": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.0.2.tgz",
-      "integrity": "sha512-31rRd6ME9NM17w0oPKqi51a6fzJAqYarnzQXK+iL8XaX+3H6VH0BQut7qHIgrv2mBASRic4oNi2KRgcbFODrsQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.1.0.tgz",
+      "integrity": "sha1-1rPF4WiSolr2MTi6SEZ2qooi7ac=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -333,27 +900,26 @@
         "glob": "7.1.2",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.7.2",
+        "istanbul-lib-instrument": "1.7.4",
         "istanbul-lib-report": "1.1.1",
         "istanbul-lib-source-maps": "1.2.1",
         "istanbul-reports": "1.1.1",
         "md5-hex": "1.3.0",
-        "merge-source-map": "1.0.3",
+        "merge-source-map": "1.0.4",
         "micromatch": "2.3.11",
         "mkdirp": "0.5.1",
         "resolve-from": "2.0.0",
         "rimraf": "2.6.1",
         "signal-exit": "3.0.2",
-        "spawn-wrap": "1.3.6",
+        "spawn-wrap": "1.3.8",
         "test-exclude": "4.1.1",
-        "yargs": "8.0.1",
+        "yargs": "8.0.2",
         "yargs-parser": "5.0.0"
       },
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2",
@@ -363,26 +929,22 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+          "bundled": true,
           "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "default-require-extensions": "1.0.0"
@@ -390,63 +952,55 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+          "bundled": true,
           "dev": true
         },
         "arr-diff": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "arr-flatten": "1.0.3"
+            "arr-flatten": "1.1.0"
           }
         },
         "arr-flatten": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-          "integrity": "sha1-onTthawIhJtr14R8RYB0XcUa37E=",
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "array-unique": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "bundled": true,
           "dev": true
         },
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "bundled": true,
           "dev": true
         },
         "babel-code-frame": {
           "version": "6.22.0",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
             "esutils": "2.0.2",
-            "js-tokens": "3.0.1"
+            "js-tokens": "3.0.2"
           }
         },
         "babel-generator": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
-          "integrity": "sha1-5xX0hsWN7SVknYiJRNUqoHxdlJc=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-messages": "6.23.0",
             "babel-runtime": "6.23.0",
-            "babel-types": "6.24.1",
+            "babel-types": "6.25.0",
             "detect-indent": "4.0.0",
             "jsesc": "1.3.0",
             "lodash": "4.17.4",
@@ -456,8 +1010,7 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0"
@@ -465,8 +1018,7 @@
         },
         "babel-runtime": {
           "version": "6.23.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "core-js": "2.4.1",
@@ -474,39 +1026,36 @@
           }
         },
         "babel-template": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
-          "integrity": "sha1-BK5RTx+Ts6JTfyoPYKWkX7gwgzM=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0",
-            "babel-traverse": "6.24.1",
-            "babel-types": "6.24.1",
-            "babylon": "6.17.2",
+            "babel-traverse": "6.25.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
             "lodash": "4.17.4"
           }
         },
         "babel-traverse": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
-          "integrity": "sha1-qzZnP9NW+aCUhlnnszjV/q2zFpU=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-code-frame": "6.22.0",
             "babel-messages": "6.23.0",
             "babel-runtime": "6.23.0",
-            "babel-types": "6.24.1",
-            "babylon": "6.17.2",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
             "debug": "2.6.8",
-            "globals": "9.17.0",
+            "globals": "9.18.0",
             "invariant": "2.2.2",
             "lodash": "4.17.4"
           }
         },
         "babel-types": {
-          "version": "6.24.1",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
-          "integrity": "sha1-oTaHncFbNga9oNkMH8dDBML/CXU=",
+          "version": "6.25.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "babel-runtime": "6.23.0",
@@ -516,31 +1065,27 @@
           }
         },
         "babylon": {
-          "version": "6.17.2",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.2.tgz",
-          "integrity": "sha1-IB0l71+JLEG65JSIsI2w3Udun1w=",
+          "version": "6.17.4",
+          "bundled": true,
           "dev": true
         },
         "balanced-match": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true
         },
         "brace-expansion": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+          "version": "1.1.8",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
         "braces": {
           "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "expand-range": "1.8.2",
@@ -550,14 +1095,12 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "bundled": true,
           "dev": true
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-hex": "1.3.0",
@@ -565,10 +1108,15 @@
             "write-file-atomic": "1.3.4"
           }
         },
+        "camelcase": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
         "center-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -578,8 +1126,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
@@ -591,8 +1138,7 @@
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -603,8 +1149,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+              "bundled": true,
               "dev": true,
               "optional": true
             }
@@ -612,48 +1157,41 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.5.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-          "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+          "bundled": true,
           "dev": true
         },
         "core-js": {
           "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+          "bundled": true,
           "dev": true
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "4.0.2",
+            "lru-cache": "4.1.1",
             "which": "1.2.14"
           }
         },
         "debug": {
           "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -661,20 +1199,17 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+          "bundled": true,
           "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "strip-bom": "2.0.0"
@@ -682,8 +1217,7 @@
         },
         "detect-indent": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "repeating": "2.0.1"
@@ -691,8 +1225,7 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "0.2.1"
@@ -700,20 +1233,17 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "bundled": true,
           "dev": true
         },
         "esutils": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "bundled": true,
           "dev": true
         },
         "execa": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -727,8 +1257,7 @@
         },
         "expand-brackets": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-posix-bracket": "0.1.1"
@@ -736,8 +1265,7 @@
         },
         "expand-range": {
           "version": "1.8.2",
-          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fill-range": "2.2.3"
@@ -745,8 +1273,7 @@
         },
         "extglob": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -754,27 +1281,24 @@
         },
         "filename-regex": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+          "bundled": true,
           "dev": true
         },
         "fill-range": {
           "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-number": "2.1.0",
             "isobject": "2.1.0",
-            "randomatic": "1.1.6",
+            "randomatic": "1.1.7",
             "repeat-element": "1.1.2",
             "repeat-string": "1.6.1"
           }
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "1.0.1",
@@ -784,8 +1308,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "locate-path": "2.0.0"
@@ -793,14 +1316,12 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+          "bundled": true,
           "dev": true
         },
         "for-own": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-in": "1.0.2"
@@ -808,8 +1329,7 @@
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "4.0.2",
@@ -818,20 +1338,17 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "object-assign": "4.1.1",
@@ -840,8 +1357,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -854,8 +1370,7 @@
         },
         "glob-base": {
           "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob-parent": "2.0.0",
@@ -864,41 +1379,36 @@
         },
         "glob-parent": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-glob": "2.0.1"
           }
         },
         "globals": {
-          "version": "9.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-          "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+          "version": "9.18.0",
+          "bundled": true,
           "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
           "version": "4.0.10",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-          "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "async": "1.5.2",
             "optimist": "0.6.1",
             "source-map": "0.4.4",
-            "uglify-js": "2.8.27"
+            "uglify-js": "2.8.29"
           },
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "amdefine": "1.0.1"
@@ -908,8 +1418,7 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -917,26 +1426,22 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "bundled": true,
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-          "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+          "version": "2.5.0",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -945,14 +1450,12 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
         },
         "invariant": {
           "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
@@ -960,26 +1463,22 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "bundled": true,
           "dev": true
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "bundled": true,
           "dev": true
         },
         "is-buffer": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-          "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
@@ -987,14 +1486,12 @@
         },
         "is-dotfile": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+          "bundled": true,
           "dev": true
         },
         "is-equal-shallow": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-primitive": "2.0.0"
@@ -1002,20 +1499,17 @@
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+          "bundled": true,
           "dev": true
         },
         "is-extglob": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+          "bundled": true,
           "dev": true
         },
         "is-finite": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -1023,8 +1517,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -1032,8 +1525,7 @@
         },
         "is-glob": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-extglob": "1.0.0"
@@ -1041,8 +1533,7 @@
         },
         "is-number": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "kind-of": "3.2.2"
@@ -1050,44 +1541,37 @@
         },
         "is-posix-bracket": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+          "bundled": true,
           "dev": true
         },
         "is-primitive": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+          "bundled": true,
           "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "bundled": true,
           "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
         "isobject": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isarray": "1.0.0"
@@ -1095,38 +1579,34 @@
         },
         "istanbul-lib-coverage": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-          "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q==",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
           "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-          "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "append-transform": "0.4.0"
           }
         },
         "istanbul-lib-instrument": {
-          "version": "1.7.2",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
-          "integrity": "sha512-lPgUY+Pa5dlq2/l0qs1PJZ54QPSfo+s4+UZdkb2d0hbOyrEIAbUJphBLFjEyXBdeCONgGRADFzs3ojfFtmuwFA==",
+          "version": "1.7.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "babel-generator": "6.24.1",
-            "babel-template": "6.24.1",
-            "babel-traverse": "6.24.1",
-            "babel-types": "6.24.1",
-            "babylon": "6.17.2",
+            "babel-generator": "6.25.0",
+            "babel-template": "6.25.0",
+            "babel-traverse": "6.25.0",
+            "babel-types": "6.25.0",
+            "babylon": "6.17.4",
             "istanbul-lib-coverage": "1.1.1",
             "semver": "5.3.0"
           }
         },
         "istanbul-lib-report": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-          "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "istanbul-lib-coverage": "1.1.1",
@@ -1137,8 +1617,7 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "has-flag": "1.0.0"
@@ -1148,8 +1627,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-          "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "debug": "2.6.8",
@@ -1161,29 +1639,25 @@
         },
         "istanbul-reports": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-          "integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "handlebars": "4.0.10"
           }
         },
         "js-tokens": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-          "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+          "version": "3.0.2",
+          "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+          "bundled": true,
           "dev": true
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-buffer": "1.1.5"
@@ -1191,15 +1665,13 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
@@ -1207,8 +1679,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -1220,8 +1691,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-locate": "2.0.0",
@@ -1230,37 +1700,32 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "bundled": true,
               "dev": true
             }
           }
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "bundled": true,
           "dev": true
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+          "bundled": true,
           "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "3.0.1"
+            "js-tokens": "3.0.2"
           }
         },
         "lru-cache": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-          "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
@@ -1269,8 +1734,7 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "md5-o-matic": "0.1.1"
@@ -1278,23 +1742,20 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+          "bundled": true,
           "dev": true
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "mimic-fn": "1.1.0"
           }
         },
         "merge-source-map": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.3.tgz",
-          "integrity": "sha1-2hQV8nIqURnbB7FMT5c0EIY6Kr8=",
+          "version": "1.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "source-map": "0.5.6"
@@ -1302,8 +1763,7 @@
         },
         "micromatch": {
           "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arr-diff": "2.0.0",
@@ -1323,29 +1783,25 @@
         },
         "mimic-fn": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-          "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "1.1.8"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "bundled": true,
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -1353,17 +1809,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "bundled": true,
           "dev": true
         },
         "normalize-package-data": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-          "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+          "version": "2.4.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.4.2",
+            "hosted-git-info": "2.5.0",
             "is-builtin-module": "1.0.0",
             "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1"
@@ -1371,17 +1825,15 @@
         },
         "normalize-path": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "remove-trailing-separator": "1.0.1"
+            "remove-trailing-separator": "1.0.2"
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "2.0.1"
@@ -1389,20 +1841,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true
         },
         "object.omit": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "for-own": "0.1.5",
@@ -1411,8 +1860,7 @@
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -1420,8 +1868,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8",
@@ -1430,14 +1877,12 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-          "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "execa": "0.5.1",
@@ -1447,20 +1892,17 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-          "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+          "bundled": true,
           "dev": true
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "p-limit": "1.1.0"
@@ -1468,8 +1910,7 @@
         },
         "parse-glob": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob-base": "0.3.0",
@@ -1480,8 +1921,7 @@
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "error-ex": "1.3.1"
@@ -1489,8 +1929,7 @@
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie-promise": "2.0.1"
@@ -1498,26 +1937,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "bundled": true,
           "dev": true
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -1527,20 +1962,17 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "bundled": true,
           "dev": true
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "bundled": true,
           "dev": true
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pinkie": "2.0.4"
@@ -1548,8 +1980,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2"
@@ -1557,8 +1988,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -1569,41 +1999,64 @@
         },
         "preserve": {
           "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+          "bundled": true,
           "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
         "randomatic": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
-          "integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
+          "version": "1.1.7",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "kind-of": "3.2.2"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
+            }
           }
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "load-json-file": "1.1.0",
-            "normalize-package-data": "2.3.8",
+            "normalize-package-data": "2.4.0",
             "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "find-up": "1.1.2",
@@ -1612,8 +2065,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "path-exists": "2.1.0",
@@ -1624,14 +2076,12 @@
         },
         "regenerator-runtime": {
           "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
+          "bundled": true,
           "dev": true
         },
         "regex-cache": {
           "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-          "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-equal-shallow": "0.1.3",
@@ -1639,27 +2089,23 @@
           }
         },
         "remove-trailing-separator": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
-          "integrity": "sha1-YV67lq9VlVLUv0BXyENtSGq2PMQ=",
+          "version": "1.0.2",
+          "bundled": true,
           "dev": true
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+          "bundled": true,
           "dev": true
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+          "bundled": true,
           "dev": true
         },
         "repeating": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-finite": "1.0.2"
@@ -1667,26 +2113,22 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "bundled": true,
           "dev": true
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -1695,8 +2137,7 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -1704,38 +2145,32 @@
         },
         "semver": {
           "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+          "bundled": true,
           "dev": true
         },
         "source-map": {
           "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.6.tgz",
-          "integrity": "sha512-5bEhZ11kqwoECJwfbur2ALU1NBnnCNbFzdWGHEXCiSsVhH+Ubz6eesa1DuQcm05pk38HknqP556f3CFhqws2ZA==",
+          "version": "1.3.8",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "1.5.6",
@@ -1748,8 +2183,7 @@
         },
         "spdx-correct": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-license-ids": "1.2.2"
@@ -1757,38 +2191,46 @@
         },
         "spdx-expression-parse": {
           "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "bundled": true,
           "dev": true
         },
         "spdx-license-ids": {
           "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "bundled": true,
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true,
+              "dev": true
+            },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "bundled": true,
               "dev": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "3.0.0"
+              }
             }
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -1796,8 +2238,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-utf8": "0.2.1"
@@ -1805,20 +2246,17 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+          "bundled": true,
           "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-          "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
@@ -1830,20 +2268,17 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+          "bundled": true,
           "dev": true
         },
         "trim-right": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+          "bundled": true,
           "dev": true
         },
         "uglify-js": {
-          "version": "2.8.27",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
-          "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+          "version": "2.8.29",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -1852,17 +2287,9 @@
             "yargs": "3.10.0"
           },
           "dependencies": {
-            "camelcase": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-              "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-              "dev": true,
-              "optional": true
-            },
             "yargs": {
               "version": "3.10.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+              "bundled": true,
               "dev": true,
               "optional": true,
               "requires": {
@@ -1876,15 +2303,13 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "1.0.2",
@@ -1893,8 +2318,7 @@
         },
         "which": {
           "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "2.0.0"
@@ -1902,27 +2326,23 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "1.0.2",
@@ -1931,8 +2351,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -1944,14 +2363,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -1961,20 +2378,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
-          "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
+          "version": "8.0.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "4.1.0",
@@ -1986,7 +2400,7 @@
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
-            "string-width": "2.0.0",
+            "string-width": "2.1.0",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
             "yargs-parser": "7.0.0"
@@ -1994,14 +2408,12 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+              "bundled": true,
               "dev": true
             },
             "cliui": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "string-width": "1.0.2",
@@ -2011,8 +2423,7 @@
               "dependencies": {
                 "string-width": {
                   "version": "1.0.2",
-                  "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "bundled": true,
                   "dev": true,
                   "requires": {
                     "code-point-at": "1.1.0",
@@ -2024,8 +2435,7 @@
             },
             "load-json-file": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-              "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -2036,8 +2446,7 @@
             },
             "path-type": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-              "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "pify": "2.3.0"
@@ -2045,19 +2454,17 @@
             },
             "read-pkg": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-              "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "load-json-file": "2.0.0",
-                "normalize-package-data": "2.3.8",
+                "normalize-package-data": "2.4.0",
                 "path-type": "2.0.0"
               }
             },
             "read-pkg-up": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-              "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "find-up": "2.1.0",
@@ -2066,14 +2473,12 @@
             },
             "strip-bom": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+              "bundled": true,
               "dev": true
             },
             "yargs-parser": {
               "version": "7.0.0",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-              "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "camelcase": "4.1.0"
@@ -2083,8 +2488,7 @@
         },
         "yargs-parser": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "camelcase": "3.0.0"
@@ -2092,13 +2496,18 @@
           "dependencies": {
             "camelcase": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-              "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+              "bundled": true,
               "dev": true
             }
           }
         }
       }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -2130,6 +2539,73 @@
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+      "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+      "dev": true
+    },
+    "request": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+      "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.11.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "2.0.6",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.16",
+        "oauth-sign": "0.8.2",
+        "qs": "6.3.2",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.4.3",
+        "uuid": "3.1.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
     "samsam": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
@@ -2137,9 +2613,9 @@
       "dev": true
     },
     "sinon": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.4.tgz",
-      "integrity": "sha1-RmrY0brobW21GqIYuS6Ze8Pl24g=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "requires": {
         "diff": "3.2.0",
@@ -2152,6 +2628,68 @@
         "type-detect": "4.0.3"
       }
     },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
     "supports-color": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -2162,1714 +2700,13 @@
       }
     },
     "swatchjs": {
-      "version": "0.1.0",
+      "version": "0.1.34",
+      "resolved": "https://registry.npmjs.org/swatchjs/-/swatchjs-0.1.34.tgz",
+      "integrity": "sha1-2cHiPg0FuaX+OFft5DI59mHOPYo=",
       "dev": true,
       "requires": {
         "function-arguments": "1.0.8",
-        "joi": "10.6.0",
-        "to-camel-case": "1.0.0"
-      },
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "browser-stdout": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "chai": {
-          "version": "4.0.2",
-          "bundled": true,
-          "requires": {
-            "assertion-error": "1.0.2",
-            "check-error": "1.0.2",
-            "deep-eql": "2.0.2",
-            "get-func-name": "2.0.0",
-            "pathval": "1.1.0",
-            "type-detect": "4.0.3"
-          }
-        },
-        "check-error": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "bundled": true,
-          "requires": {
-            "graceful-readlink": "1.0.1"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "debug": {
-          "version": "2.6.0",
-          "bundled": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "deep-eql": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "type-detect": "3.0.0"
-          },
-          "dependencies": {
-            "type-detect": {
-              "version": "3.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "diff": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "function-arguments": {
-          "version": "1.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "get-func-name": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.1",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "growl": {
-          "version": "1.9.2",
-          "bundled": true
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "hoek": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "isemail": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "items": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "joi": {
-          "version": "10.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "4.1.1",
-            "isemail": "2.2.1",
-            "items": "2.1.1",
-            "topo": "2.0.2"
-          }
-        },
-        "json3": {
-          "version": "3.3.2",
-          "bundled": true
-        },
-        "lodash._baseassign": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash.keys": "3.1.2"
-          }
-        },
-        "lodash._basecopy": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "lodash._basecreate": {
-          "version": "3.0.3",
-          "bundled": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "bundled": true
-        },
-        "lodash._isiterateecall": {
-          "version": "3.0.9",
-          "bundled": true
-        },
-        "lodash.create": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash._baseassign": "3.2.0",
-            "lodash._basecreate": "3.0.3",
-            "lodash._isiterateecall": "3.0.9"
-          }
-        },
-        "lodash.isarguments": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "bundled": true
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "mocha": {
-          "version": "3.4.2",
-          "bundled": true,
-          "requires": {
-            "browser-stdout": "1.3.0",
-            "commander": "2.9.0",
-            "debug": "2.6.0",
-            "diff": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "glob": "7.1.1",
-            "growl": "1.9.2",
-            "json3": "3.3.2",
-            "lodash.create": "3.1.1",
-            "mkdirp": "0.5.1",
-            "supports-color": "3.1.2"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "bundled": true
-        },
-        "nyc": {
-          "version": "11.0.3",
-          "bundled": true,
-          "requires": {
-            "archy": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-            "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-            "caching-transform": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-            "convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-            "debug-log": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-            "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-            "find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-            "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-            "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-            "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-            "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-            "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-            "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-            "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-            "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-            "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-            "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-            "merge-source-map": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-            "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "resolve-from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-            "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-            "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "spawn-wrap": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.7.tgz",
-            "test-exclude": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-            "yargs": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-            "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
-          },
-          "dependencies": {
-            "align-text": {
-              "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-              "bundled": true,
-              "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-              }
-            },
-            "amdefine": {
-              "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-              "bundled": true
-            },
-            "ansi-regex": {
-              "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "bundled": true
-            },
-            "append-transform": {
-              "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
-              "bundled": true,
-              "requires": {
-                "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
-              }
-            },
-            "archy": {
-              "version": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-              "bundled": true
-            },
-            "arr-diff": {
-              "version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz"
-              }
-            },
-            "arr-flatten": {
-              "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.3.tgz",
-              "bundled": true
-            },
-            "array-unique": {
-              "version": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-              "bundled": true
-            },
-            "arrify": {
-              "version": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-              "bundled": true
-            },
-            "async": {
-              "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "bundled": true
-            },
-            "babel-code-frame": {
-              "version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-              "bundled": true,
-              "requires": {
-                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-              }
-            },
-            "babel-generator": {
-              "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-              "bundled": true,
-              "requires": {
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-                "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-              }
-            },
-            "babel-messages": {
-              "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-              }
-            },
-            "babel-runtime": {
-              "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "bundled": true,
-              "requires": {
-                "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-                "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-              }
-            },
-            "babel-template": {
-              "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-              }
-            },
-            "babel-traverse": {
-              "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-              "bundled": true,
-              "requires": {
-                "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-                "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
-              }
-            },
-            "babel-types": {
-              "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "bundled": true,
-              "requires": {
-                "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-                "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-              }
-            },
-            "babylon": {
-              "version": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-              }
-            },
-            "braces": {
-              "version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-              "bundled": true,
-              "requires": {
-                "expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                "preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-              }
-            },
-            "builtin-modules": {
-              "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-              "bundled": true
-            },
-            "caching-transform": {
-              "version": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "md5-hex": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "write-file-atomic": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz"
-              }
-            },
-            "camelcase": {
-              "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-              "bundled": true,
-              "optional": true
-            },
-            "center-align": {
-              "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-              }
-            },
-            "chalk": {
-              "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-              }
-            },
-            "cliui": {
-              "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-              },
-              "dependencies": {
-                "wordwrap": {
-                  "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            },
-            "code-point-at": {
-              "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-              "bundled": true
-            },
-            "commondir": {
-              "version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-              "bundled": true
-            },
-            "convert-source-map": {
-              "version": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-              "bundled": true
-            },
-            "core-js": {
-              "version": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "bundled": true
-            },
-            "cross-spawn": {
-              "version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-              }
-            },
-            "debug": {
-              "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "bundled": true,
-              "requires": {
-                "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-              }
-            },
-            "debug-log": {
-              "version": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-              "bundled": true
-            },
-            "decamelize": {
-              "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-              "bundled": true
-            },
-            "default-require-extensions": {
-              "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-              }
-            },
-            "detect-indent": {
-              "version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
-              }
-            },
-            "error-ex": {
-              "version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-              "bundled": true,
-              "requires": {
-                "is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-              }
-            },
-            "escape-string-regexp": {
-              "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "bundled": true
-            },
-            "esutils": {
-              "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "bundled": true
-            },
-            "execa": {
-              "version": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-                "get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-                "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                "npm-run-path": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-                "p-finally": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                "strip-eof": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz"
-              }
-            },
-            "expand-brackets": {
-              "version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-              "bundled": true,
-              "requires": {
-                "is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-              }
-            },
-            "expand-range": {
-              "version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-              "bundled": true,
-              "requires": {
-                "fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
-              }
-            },
-            "extglob": {
-              "version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-              }
-            },
-            "filename-regex": {
-              "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-              "bundled": true
-            },
-            "fill-range": {
-              "version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-              "bundled": true,
-              "requires": {
-                "is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                "isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                "randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-                "repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-              }
-            },
-            "find-cache-dir": {
-              "version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-              "bundled": true,
-              "requires": {
-                "commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
-              }
-            },
-            "find-up": {
-              "version": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "locate-path": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz"
-              }
-            },
-            "for-in": {
-              "version": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-              "bundled": true
-            },
-            "for-own": {
-              "version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-              "bundled": true,
-              "requires": {
-                "for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-              }
-            },
-            "foreground-child": {
-              "version": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-              }
-            },
-            "fs.realpath": {
-              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "bundled": true
-            },
-            "get-caller-file": {
-              "version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-              "bundled": true
-            },
-            "get-stream": {
-              "version": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-              "bundled": true,
-              "requires": {
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-              }
-            },
-            "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-              }
-            },
-            "glob-base": {
-              "version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-              "bundled": true,
-              "requires": {
-                "glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-              }
-            },
-            "glob-parent": {
-              "version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-              }
-            },
-            "globals": {
-              "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-              "bundled": true
-            },
-            "graceful-fs": {
-              "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "bundled": true
-            },
-            "handlebars": {
-              "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-              "bundled": true,
-              "requires": {
-                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz"
-              },
-              "dependencies": {
-                "source-map": {
-                  "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                  }
-                }
-              }
-            },
-            "has-ansi": {
-              "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-              }
-            },
-            "has-flag": {
-              "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-              "bundled": true
-            },
-            "imurmurhash": {
-              "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "bundled": true,
-              "requires": {
-                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-              }
-            },
-            "inherits": {
-              "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "bundled": true
-            },
-            "invariant": {
-              "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-              "bundled": true,
-              "requires": {
-                "loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
-              }
-            },
-            "invert-kv": {
-              "version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-              "bundled": true
-            },
-            "is-arrayish": {
-              "version": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-              "bundled": true
-            },
-            "is-buffer": {
-              "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-              "bundled": true
-            },
-            "is-builtin-module": {
-              "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-              }
-            },
-            "is-dotfile": {
-              "version": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-              "bundled": true
-            },
-            "is-equal-shallow": {
-              "version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-              "bundled": true,
-              "requires": {
-                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-              }
-            },
-            "is-extendable": {
-              "version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-              "bundled": true
-            },
-            "is-extglob": {
-              "version": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-              "bundled": true
-            },
-            "is-finite": {
-              "version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-              }
-            },
-            "is-glob": {
-              "version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-              }
-            },
-            "is-number": {
-              "version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-              }
-            },
-            "is-posix-bracket": {
-              "version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-              "bundled": true
-            },
-            "is-primitive": {
-              "version": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-              "bundled": true
-            },
-            "is-stream": {
-              "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-              "bundled": true
-            },
-            "is-utf8": {
-              "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-              "bundled": true
-            },
-            "isarray": {
-              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "bundled": true
-            },
-            "isexe": {
-              "version": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-              "bundled": true
-            },
-            "isobject": {
-              "version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-              }
-            },
-            "istanbul-lib-coverage": {
-              "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-              "bundled": true
-            },
-            "istanbul-lib-hook": {
-              "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-              "bundled": true,
-              "requires": {
-                "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
-              }
-            },
-            "istanbul-lib-instrument": {
-              "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.3.tgz",
-              "bundled": true,
-              "requires": {
-                "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-                "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-                "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-              }
-            },
-            "istanbul-lib-report": {
-              "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
-              "bundled": true,
-              "requires": {
-                "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                  }
-                }
-              }
-            },
-            "istanbul-lib-source-maps": {
-              "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
-              "bundled": true,
-              "requires": {
-                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-              }
-            },
-            "istanbul-reports": {
-              "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-              "bundled": true,
-              "requires": {
-                "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz"
-              }
-            },
-            "js-tokens": {
-              "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-              "bundled": true
-            },
-            "jsesc": {
-              "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-              "bundled": true
-            },
-            "kind-of": {
-              "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-              }
-            },
-            "lazy-cache": {
-              "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-              "bundled": true,
-              "optional": true
-            },
-            "lcid": {
-              "version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-              }
-            },
-            "load-json-file": {
-              "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
-              }
-            },
-            "locate-path": {
-              "version": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "p-locate": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-                "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz"
-              },
-              "dependencies": {
-                "path-exists": {
-                  "version": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                  "bundled": true
-                }
-              }
-            },
-            "lodash": {
-              "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-              "bundled": true
-            },
-            "longest": {
-              "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-              "bundled": true
-            },
-            "loose-envify": {
-              "version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "bundled": true,
-              "requires": {
-                "js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
-              }
-            },
-            "lru-cache": {
-              "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-              "bundled": true,
-              "requires": {
-                "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-              }
-            },
-            "md5-hex": {
-              "version": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-              "bundled": true,
-              "requires": {
-                "md5-o-matic": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz"
-              }
-            },
-            "md5-o-matic": {
-              "version": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-              "bundled": true
-            },
-            "mem": {
-              "version": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "mimic-fn": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz"
-              }
-            },
-            "merge-source-map": {
-              "version": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-              "bundled": true,
-              "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-              }
-            },
-            "micromatch": {
-              "version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "bundled": true,
-              "requires": {
-                "arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                "array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                "braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                "expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                "extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                "filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                "normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                "object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                "parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                "regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
-              }
-            },
-            "mimic-fn": {
-              "version": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-              "bundled": true
-            },
-            "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
-              }
-            },
-            "minimist": {
-              "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "bundled": true
-            },
-            "mkdirp": {
-              "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "bundled": true,
-              "requires": {
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-              }
-            },
-            "ms": {
-              "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "bundled": true
-            },
-            "normalize-package-data": {
-              "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-                "is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                "semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-                "validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
-              }
-            },
-            "normalize-path": {
-              "version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-              "bundled": true,
-              "requires": {
-                "remove-trailing-separator": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-              }
-            },
-            "npm-run-path": {
-              "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-              "bundled": true,
-              "requires": {
-                "path-key": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz"
-              }
-            },
-            "number-is-nan": {
-              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-              "bundled": true
-            },
-            "object-assign": {
-              "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-              "bundled": true
-            },
-            "object.omit": {
-              "version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                "is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-              }
-            },
-            "once": {
-              "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "bundled": true,
-              "requires": {
-                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-              }
-            },
-            "optimist": {
-              "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-              "bundled": true,
-              "requires": {
-                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-              }
-            },
-            "os-homedir": {
-              "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "bundled": true
-            },
-            "os-locale": {
-              "version": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "execa": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-                "lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                "mem": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz"
-              }
-            },
-            "p-finally": {
-              "version": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-              "bundled": true
-            },
-            "p-limit": {
-              "version": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-              "bundled": true
-            },
-            "p-locate": {
-              "version": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "p-limit": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz"
-              }
-            },
-            "parse-glob": {
-              "version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-              "bundled": true,
-              "requires": {
-                "glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                "is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-                "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                "is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-              }
-            },
-            "parse-json": {
-              "version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-              "bundled": true,
-              "requires": {
-                "error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
-              }
-            },
-            "path-exists": {
-              "version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-              }
-            },
-            "path-is-absolute": {
-              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "bundled": true
-            },
-            "path-key": {
-              "version": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-              "bundled": true
-            },
-            "path-parse": {
-              "version": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-              "bundled": true
-            },
-            "path-type": {
-              "version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-              }
-            },
-            "pify": {
-              "version": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-              "bundled": true
-            },
-            "pinkie": {
-              "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-              "bundled": true
-            },
-            "pinkie-promise": {
-              "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-              }
-            },
-            "pkg-dir": {
-              "version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                  }
-                }
-              }
-            },
-            "preserve": {
-              "version": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-              "bundled": true
-            },
-            "pseudomap": {
-              "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "bundled": true
-            },
-            "randomatic": {
-              "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-              "bundled": true,
-              "requires": {
-                "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
-              },
-              "dependencies": {
-                "is-number": {
-                  "version": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                      "bundled": true,
-                      "requires": {
-                        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                      }
-                    }
-                  }
-                },
-                "kind-of": {
-                  "version": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                  }
-                }
-              }
-            },
-            "read-pkg": {
-              "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                "path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
-              }
-            },
-            "read-pkg-up": {
-              "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
-              },
-              "dependencies": {
-                "find-up": {
-                  "version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-                  }
-                }
-              }
-            },
-            "regenerator-runtime": {
-              "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-              "bundled": true
-            },
-            "regex-cache": {
-              "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-              "bundled": true,
-              "requires": {
-                "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                "is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-              }
-            },
-            "remove-trailing-separator": {
-              "version": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-              "bundled": true
-            },
-            "repeat-element": {
-              "version": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-              "bundled": true
-            },
-            "repeat-string": {
-              "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-              "bundled": true
-            },
-            "repeating": {
-              "version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
-              }
-            },
-            "require-directory": {
-              "version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-              "bundled": true
-            },
-            "require-main-filename": {
-              "version": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-              "bundled": true
-            },
-            "resolve-from": {
-              "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-              "bundled": true
-            },
-            "right-align": {
-              "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
-              }
-            },
-            "rimraf": {
-              "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-              "bundled": true,
-              "requires": {
-                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-              }
-            },
-            "semver": {
-              "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-              "bundled": true
-            },
-            "set-blocking": {
-              "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-              "bundled": true
-            },
-            "slide": {
-              "version": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-              "bundled": true
-            },
-            "source-map": {
-              "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-              "bundled": true
-            },
-            "spawn-wrap": {
-              "version": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.3.7.tgz",
-              "bundled": true,
-              "requires": {
-                "foreground-child": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
-                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                "os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-                "signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                "which": "https://registry.npmjs.org/which/-/which-1.2.14.tgz"
-              }
-            },
-            "spdx-correct": {
-              "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "bundled": true,
-              "requires": {
-                "spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-              "bundled": true
-            },
-            "spdx-license-ids": {
-              "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-              },
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                  "bundled": true
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-              }
-            },
-            "strip-bom": {
-              "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-              }
-            },
-            "strip-eof": {
-              "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-              "bundled": true
-            },
-            "supports-color": {
-              "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "bundled": true
-            },
-            "test-exclude": {
-              "version": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-              "bundled": true,
-              "requires": {
-                "arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-              }
-            },
-            "to-fast-properties": {
-              "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-              "bundled": true
-            },
-            "trim-right": {
-              "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-              "bundled": true
-            },
-            "uglify-js": {
-              "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
-              },
-              "dependencies": {
-                "yargs": {
-                  "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                    "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                    "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                    "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                  }
-                }
-              }
-            },
-            "uglify-to-browserify": {
-              "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-              "bundled": true,
-              "optional": true
-            },
-            "validate-npm-package-license": {
-              "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                "spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-              }
-            },
-            "which": {
-              "version": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-              "bundled": true,
-              "requires": {
-                "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-              }
-            },
-            "which-module": {
-              "version": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-              "bundled": true
-            },
-            "window-size": {
-              "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-              "bundled": true,
-              "optional": true
-            },
-            "wordwrap": {
-              "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-              "bundled": true
-            },
-            "wrap-ansi": {
-              "version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-              "bundled": true,
-              "requires": {
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-              },
-              "dependencies": {
-                "string-width": {
-                  "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                    "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                  }
-                }
-              }
-            },
-            "wrappy": {
-              "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-              "bundled": true,
-              "requires": {
-                "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                "imurmurhash": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-                "slide": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
-              }
-            },
-            "y18n": {
-              "version": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-              "bundled": true
-            },
-            "yallist": {
-              "version": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-              "bundled": true
-            },
-            "yargs": {
-              "version": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-              "bundled": true,
-              "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                "cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                "get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-                "os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-                "read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-                "require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-                "require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                "set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-                "string-width": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-                "which-module": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-                "y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-                "yargs-parser": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-                  "bundled": true
-                },
-                "cliui": {
-                  "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "bundled": true,
-                      "requires": {
-                        "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                        "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                      }
-                    }
-                  }
-                },
-                "load-json-file": {
-                  "version": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-                  }
-                },
-                "path-type": {
-                  "version": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                  }
-                },
-                "read-pkg": {
-                  "version": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-                    "normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-                    "path-type": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz"
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "find-up": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-                    "read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz"
-                  }
-                },
-                "strip-bom": {
-                  "version": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-                  "bundled": true
-                },
-                "yargs-parser": {
-                  "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-                  "bundled": true,
-                  "requires": {
-                    "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz"
-                  }
-                }
-              }
-            },
-            "yargs-parser": {
-              "version": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-              "bundled": true,
-              "requires": {
-                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-                  "bundled": true
-                }
-              }
-            }
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "pathval": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        },
-        "to-camel-case": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "to-space-case": "1.0.0"
-          }
-        },
-        "to-no-case": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "to-space-case": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "to-no-case": "1.0.2"
-          }
-        },
-        "topo": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "4.1.1"
-          }
-        },
-        "type-detect": {
-          "version": "4.0.3",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        }
+        "joi": "10.6.0"
       }
     },
     "text-encoding": {
@@ -3878,16 +2715,84 @@
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+      "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+      "dev": true
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
     "type-detect": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
       "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
       "dev": true
     },
+    "urlgrey": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "nyc mocha 'test/**/*.test.js'",
+    "coveralls": "nyc report --reporter=text-lcov | ./node_modules/coveralls/bin/coveralls.js",
+    "codecov": "nyc report --reporter=lcov > coverage.lcov && codecov",
     "test:debug": "mocha --debug-brk"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-express",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Express adapter for swatchjs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   },
   "homepage": "https://github.com/builtforme/swatchjs-express#readme",
   "devDependencies": {
-    "swatchjs": "^0.1.0",
     "chai": "^4.0.2",
+    "codecov": "^2.3.0",
+    "coveralls": "^2.13.1",
     "mocha": "^3.4.2",
     "nyc": "^11.0.2",
-    "sinon": "^2.3.4"
+    "sinon": "^2.3.4",
+    "swatchjs": "^0.1.0"
   },
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
Following in the footsteps of https://github.com/builtforme/swatchjs-koa/pull/10m builtforme/swatchjs#19, and builtforme/swatchjs#20 this PR adds integration with coveralls and codecov (since I'm not sure which is better) and adds badges to the README to make it clear what the code coverage is at a glance.