### PR TITLE
Fix POST Body handling

### DIFF
--- a/lib/middleware/methods/get.js
+++ b/lib/middleware/methods/get.js
@@ -1,5 +1,5 @@
-function get(expressCtx) {
-  return expressCtx.query;
+function get(req) {
+  return req.query;
 }
 
 module.exports = get;

--- a/lib/middleware/methods/post.js
+++ b/lib/middleware/methods/post.js
@@ -1,5 +1,5 @@
-function post(expressCtx) {
-  return expressCtx.request.body;
+function post(req) {
+  return req.body;
 }
 
 module.exports = post;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-express",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-express",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Express adapter for swatchjs",
   "main": "index.js",
   "scripts": {

--- a/test/middleware/methods/get.test.js
+++ b/test/middleware/methods/get.test.js
@@ -3,12 +3,12 @@ const get = require('../../../lib/middleware/methods/get');
 
 describe('get', () => {
   it('returns ctx.query', () => {
-    const expressCtx = {
+    const req = {
       query: {
         a: 1,
         b: 2,
       },
     };
-    expect(get(expressCtx)).to.deep.equal(expressCtx.query);
+    expect(get(req)).to.deep.equal(req.query);
   });
 });

--- a/test/middleware/methods/post.test.js
+++ b/test/middleware/methods/post.test.js
@@ -3,14 +3,12 @@ const post = require('../../../lib/middleware/methods/post');
 
 describe('post', () => {
   it('returns ctx.request.body', () => {
-    const expressCtx = {
-      request: {
-        body: {
-          a: 1,
-          b: 2,
-        },
+    const req = {
+      body: {
+        a: 1,
+        b: 2,
       },
     };
-    expect(post(expressCtx)).to.deep.equal(expressCtx.request.body);
+    expect(post(req)).to.deep.equal(req.body);
   });
 });


### PR DESCRIPTION
Turns out it's not really the expressContext but the body that's being passed into our handlers, so POST needs to get at the body.