### PR TITLE
Update swatch context properties from Express request

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,8 @@
         "ecmaVersion": 8,
         "sourceType": "module",
         "ecmaFeatures": {}
+    },
+    "rules": {
+        "comma-dangle": "off"
     }
 }

--- a/.nycrc
+++ b/.nycrc
@@ -8,7 +8,7 @@
     ],
     "all": true,
     "statements": 100,
-    "branch": 88.46,
+    "branch": 89.47,
     "functions": 100,
     "lines": 100,
     "check-coverage": true

--- a/lib/context.js
+++ b/lib/context.js
@@ -13,20 +13,19 @@ function init(options) {
     req.expressCtx.swatchCtx.expressCtx = () => (req.expressCtx);
 
     req.expressCtx.swatchCtx.req = {
-      // TODO: These are all things that swatchjs-koa handles.
-      // Leaving them here for us to add them into the express version in the future.
-
-      // headers: Object.assign({}, expressCtx.request.headers),
+      headers: Object.assign({}, req.headers),
       // href: expressCtx.request.href,
       // host: expressCtx.request.host,
-      // method: expressCtx.request.method,
+      method: req.method,
       // origin: expressCtx.request.origin,
-      // path: expressCtx.request.path,
-      // protocol: expressCtx.request.protocol,
-      // query: expressCtx.request.query,
-      // secure: expressCtx.request.secure,
+      path: req.path,
+      protocol: req.protocol,
+      query: req.query,
+      secure: req.secure,
       // url: expressCtx.request.url,
     };
+
+    // Set internal properties for Swatch request context
     req.expressCtx.swatchCtx.request = {
       onException: options.onException,
     };

--- a/lib/context.js
+++ b/lib/context.js
@@ -14,15 +14,15 @@ function init(options) {
 
     req.expressCtx.swatchCtx.req = {
       headers: Object.assign({}, req.headers),
-      // href: expressCtx.request.href,
-      // host: expressCtx.request.host,
+      href: `${req.protocol}://${req.get('host')}${req.originalUrl}`,
+      host: req.get('host'),
       method: req.method,
-      // origin: expressCtx.request.origin,
+      origin: req.get('origin'),
       path: req.path,
       protocol: req.protocol,
       query: req.query,
       secure: req.secure,
-      // url: expressCtx.request.url,
+      url: req.path,
     };
 
     // Set internal properties for Swatch request context

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -10,7 +10,7 @@ function expose(app, model, opts) {
   function addMethod(method) {
     function addRoute(supportedVerb) {
       const verb = supportedVerb.trim();
-      const paramFn = middleware.default.methods[verb];
+      const paramFn = middleware.methods[verb];
 
       const { noAuth } = method.metadata;
       const methodHandler = handlers[verb](method);
@@ -20,7 +20,7 @@ function expose(app, model, opts) {
       //   handler.wrapped(method.handle, options);
 
       const contextMiddleware = context.init(options);
-      const loggerMiddleware = middleware.default.logger.init;
+      const loggerMiddleware = middleware.logger.init;
       if (!noAuth && !options.authAdapter) {
         // TODO: We need to figure out what to do here;
         // the very simple example in the README won't work.

--- a/lib/expose.js
+++ b/lib/expose.js
@@ -38,7 +38,7 @@ function expose(app, model, opts) {
       const loggerM = [contextMiddleware, loggerMiddleware];
       const adapterM = loggerM.concat(adapterMiddleware);
       const validatorM = adapterM.concat(
-        [validateMiddleware],
+        [validateMiddleware]
       );
       const methodM = validatorM.concat(methodMiddleware);
       const allMiddleware = methodM.concat([methodHandler]);

--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -1,8 +1,8 @@
-import logger from './logger';
-import methods from './methods';
-import response from './response';
+const logger = require('./logger');
+const methods = require('./methods');
+const response = require('./response');
 
-export default {
+module.exports = {
   logger,
   methods,
   response,

--- a/lib/middleware/logger/index.js
+++ b/lib/middleware/logger/index.js
@@ -1,4 +1,4 @@
-import bunyan from 'bunyan';
+const bunyan = require('bunyan');
 
 function ensureLogger(logger) {
   // Check for a logger created by the client
@@ -18,6 +18,6 @@ async function initLogger(req, res, next) {
   await next();
 }
 
-export default {
+module.exports = {
   init: initLogger,
 };

--- a/lib/middleware/methods/index.js
+++ b/lib/middleware/methods/index.js
@@ -1,7 +1,7 @@
-import get from './get';
-import post from './post';
+const get = require('./get');
+const post = require('./post');
 
-export default {
+module.exports = {
   get,
   post,
 };

--- a/lib/middleware/response/index.js
+++ b/lib/middleware/response/index.js
@@ -39,7 +39,7 @@ function exception(exceptionObj) {
 function error(errorObj) {
   try {
     this.logger.error(
-      `Exception thrown by Swatch handler: ${util.inspect(errorObj)}`,
+      `Exception thrown by Swatch handler: ${util.inspect(errorObj)}`
     );
 
     // Allow client to rescue the exception and return a value
@@ -47,13 +47,13 @@ function error(errorObj) {
     const result = this.request.onException(errorObj);
 
     this.logger.warn(
-      `Exception was rescued... Success response: ${util.inspect(result)}`,
+      `Exception was rescued... Success response: ${util.inspect(result)}`
     );
 
     return success(result);
   } catch (exceptionObj) {
     this.logger.error(
-      `Exception was re-thrown...: ${util.inspect(exceptionObj)}`,
+      `Exception was re-thrown...: ${util.inspect(exceptionObj)}`
     );
 
     // Check for the internal error code/string from the `errorObj`

--- a/lib/middleware/response/index.js
+++ b/lib/middleware/response/index.js
@@ -1,4 +1,4 @@
-import util from 'util';
+const util = require('util');
 
 function getErrorMessage(errorObj) {
   return (errorObj && errorObj.message) || errorObj;
@@ -61,7 +61,7 @@ function error(errorObj) {
   }
 }
 
-export default {
+module.exports = {
   error,
   exception,
   raw,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "swatchjs-express",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
-      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.51"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/generator": {
@@ -64,16 +64,91 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
-      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
-        "js-tokens": "^3.0.0"
+        "js-tokens": "^4.0.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
+        "lodash": "^4.17.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "7.0.0-beta.51"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -105,24 +180,6 @@
         }
       }
     },
-    "@babel/parser": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
-      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
-      "dev": true
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.51",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
-      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.51",
-        "@babel/parser": "7.0.0-beta.51",
-        "@babel/types": "7.0.0-beta.51",
-        "lodash": "^4.17.5"
-      }
-    },
     "@babel/traverse": {
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
@@ -141,13 +198,53 @@
         "lodash": "^4.17.5"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "@babel/code-frame": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+          "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "@babel/highlight": "7.0.0-beta.51"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0-beta.51",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+          "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.0"
+          }
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
           }
         },
         "globals": {
@@ -155,6 +252,21 @@
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
           "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg==",
           "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },
@@ -202,9 +314,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.2.tgz",
-      "integrity": "sha512-cJrKCNcr2kv8dlDnbw+JPUGjHZzo4myaxOLmpOX8a+rgX94YeTcTMv/LFJUSByRpc+i4GgVnnhLxvMu/2Y+rqw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -546,25 +658,25 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-async-generators": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz",
       "integrity": "sha1-a8lj67FuzLrmuStZbrfzXDQqi5o=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -1101,9 +1213,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000882",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000882.tgz",
-      "integrity": "sha512-8rH1O4z9f2RWZkVPfjgjH7o91s+1S/bnw11akv8a2WK/vby9dHwvPIOPJndB9EOLhyLY+SN78MQ1lwRcQXiveg==",
+      "version": "1.0.30000885",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000885.tgz",
+      "integrity": "sha512-cXKbYwpxBLd7qHyej16JazPoUacqoVuDhvR61U7Fr5vSxMUiodzcYa1rQYRYfZ5GexV03vGZHd722vNPLjPJGQ==",
       "dev": true
     },
     "caseless": {
@@ -1140,9 +1252,9 @@
       }
     },
     "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
     "check-error": {
@@ -1179,13 +1291,14 @@
       "dev": true
     },
     "codecov": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.4.tgz",
-      "integrity": "sha512-KJyzHdg9B8U9LxXa7hS6jnEW5b1cNckLYc2YpnJ1nEFiOW+/iSzDHp+5MYEIQd9fN3/tC6WmGZmYiwxzkuGp/A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.1.0.tgz",
+      "integrity": "sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==",
       "dev": true,
       "requires": {
         "argv": "^0.0.2",
         "ignore-walk": "^3.0.1",
+        "js-yaml": "^3.12.0",
         "request": "^2.87.0",
         "urlgrey": "^0.4.4"
       }
@@ -1216,7 +1329,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -1244,10 +1357,13 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
     },
     "core-js": {
       "version": "2.5.7",
@@ -1277,7 +1393,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -1404,9 +1520,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.62",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
+      "version": "1.3.65",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.65.tgz",
+      "integrity": "sha512-tyGr+wh2c/JYBVMeflKpZ3ricwtBPyVBMtRNxYGObl7TP5bAeupgz4VZnBzQSFleZViXYTws1yZtKKFQYZyiYw==",
       "dev": true
     },
     "error-ex": {
@@ -1449,13 +1565,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.4.0.tgz",
-      "integrity": "sha512-UIpL91XGex3qtL6qwyCQJar2j3osKxK9e3ano3OcGEIRM4oWIpCkDg9x95AXEC2wMs7PnxzOkPZ2gq+tsMS9yg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.5.0.tgz",
+      "integrity": "sha512-m+az4vYehIJgl1Z0gb25KnFXeqQRdNreYsei1jdvkd9bB+UNQD3fsuiC2AWSQ56P+/t++kFSINZXFbfai+krOw==",
       "dev": true,
       "requires": {
-        "ajv": "^6.5.0",
-        "babel-code-frame": "^6.26.0",
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^3.1.0",
@@ -1470,11 +1586,11 @@
         "functional-red-black-tree": "^1.0.1",
         "glob": "^7.1.2",
         "globals": "^11.7.0",
-        "ignore": "^4.0.2",
+        "ignore": "^4.0.6",
         "imurmurhash": "^0.1.4",
-        "inquirer": "^5.2.0",
+        "inquirer": "^6.1.0",
         "is-resolvable": "^1.1.0",
-        "js-yaml": "^3.11.0",
+        "js-yaml": "^3.12.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.5",
@@ -1487,7 +1603,7 @@
         "progress": "^2.0.0",
         "regexpp": "^2.0.0",
         "require-uncached": "^1.0.3",
-        "semver": "^5.5.0",
+        "semver": "^5.5.1",
         "strip-ansi": "^4.0.0",
         "strip-json-comments": "^2.0.1",
         "table": "^4.0.3",
@@ -1533,12 +1649,12 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "fast-deep-equal": {
@@ -1571,6 +1687,12 @@
           "version": "0.4.1",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
           "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         },
         "strip-ansi": {
@@ -1735,13 +1857,13 @@
       "dev": true
     },
     "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "^0.4.0",
-        "iconv-lite": "^0.4.17",
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
       }
     },
@@ -2080,21 +2202,21 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz",
-      "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
+      "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^3.0.0",
         "chalk": "^2.0.0",
         "cli-cursor": "^2.1.0",
         "cli-width": "^2.0.0",
-        "external-editor": "^2.1.0",
+        "external-editor": "^3.0.0",
         "figures": "^2.0.0",
-        "lodash": "^4.3.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
         "run-async": "^2.2.0",
-        "rxjs": "^5.5.2",
+        "rxjs": "^6.1.0",
         "string-width": "^2.1.0",
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
@@ -2453,9 +2575,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
-      "integrity": "sha512-Oo2Si3RMKV3+lV5MsSWplDQFoTClz/24S0MMHYcgGWWmFXr6TMlqcqk/l1GtH+d5wLBwNRiqGnwDRMirtFalJw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
+      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
       "dev": true
     },
     "loose-envify": {
@@ -2508,7 +2630,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
@@ -2595,7 +2717,7 @@
           "dependencies": {
             "acorn": {
               "version": "3.3.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
               "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
               "dev": true
             }
@@ -2622,6 +2744,12 @@
             "color-convert": "^1.9.0"
           }
         },
+        "chardet": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+          "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+          "dev": true
+        },
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2634,17 +2762,17 @@
           }
         },
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.5",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+          "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "eslint": {
           "version": "4.19.1",
-          "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+          "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
           "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
           "dev": true,
           "requires": {
@@ -2721,6 +2849,17 @@
             "acorn-jsx": "^3.0.0"
           }
         },
+        "external-editor": {
+          "version": "2.2.0",
+          "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+          "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+          "dev": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -2781,6 +2920,12 @@
               }
             }
           }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         },
         "regexpp": {
           "version": "1.1.0",
@@ -4355,7 +4500,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -4534,12 +4679,12 @@
       }
     },
     "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
+      "version": "6.3.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
+      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.1"
+        "tslib": "^1.9.0"
       }
     },
     "safe-buffer": {
@@ -4594,19 +4739,19 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.5.tgz",
-      "integrity": "sha512-TcbRoWs1SdY6NOqfj0c9OEQquBoZH+qEf8799m1jjcbfWrrpyCQ3B/BpX7+NKa7Vn33Jl+Z50H4Oys3bzygK2Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz",
+      "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.1",
+        "@sinonjs/commons": "^1.0.2",
         "@sinonjs/formatio": "^2.0.0",
         "@sinonjs/samsam": "^2.0.0",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.1",
-        "nise": "^1.4.2",
-        "supports-color": "^5.4.0",
+        "lolex": "^2.7.2",
+        "nise": "^1.4.4",
+        "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
       },
       "dependencies": {
@@ -4678,9 +4823,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
     "sprintf-js": {
@@ -4778,15 +4923,9 @@
         "joi": "^13.6.0"
       }
     },
-    "symbol-observable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
-      "dev": true
-    },
     "table": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
@@ -4867,7 +5006,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -4916,6 +5055,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true
     },
     "tunnel-agent": {
@@ -5040,7 +5185,7 @@
     },
     "yargs": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-1.2.6.tgz",
       "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
       "dev": true,
       "requires": {
@@ -5049,7 +5194,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
           "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swatchjs-express",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Express adapter for swatchjs",
   "main": "index.js",
   "scripts": {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -1,24 +1,44 @@
+const sinon = require('sinon');
+
 const { expect } = require('chai');
 
 const context = require('../lib/context');
 
 describe('context', () => {
-  describe('init', () => {
-    it('returns a middleware function', (done) => {
-      const middleware = context.init({
-        onException: function onException() {},
-      });
+  const req = {
+    headers: { authorization: 'value' },
+    method: 'GET',
+    path: 'some/path',
+    protocol: 'http',
+    query: '?name=test',
+    secure: false,
+  };
+  const res = {};
 
-      const req = {};
-      const res = {};
+  describe('init', () => {
+    it('returns a middleware function', async () => {
+      const options = {
+        onException: sinon.stub(),
+      };
+      const middleware = context.init(options);
+
       async function next() {
+        expect(options.onException.called).to.equal(false);
+
         expect(req.expressCtx).not.to.be.a('null');
+
+        expect(req.expressCtx.swatchCtx.req.headers).to.deep.equal(req.headers);
+        expect(req.expressCtx.swatchCtx.req.method).to.deep.equal('GET');
+        expect(req.expressCtx.swatchCtx.req.path).to.deep.equal('some/path');
+        expect(req.expressCtx.swatchCtx.req.protocol).to.deep.equal('http');
+        expect(req.expressCtx.swatchCtx.req.query).to.deep.equal('?name=test');
+        expect(req.expressCtx.swatchCtx.req.secure).to.deep.equal(false);
 
         // Make sure we can get the expressCtx from the swatchCtx
         expect(req.expressCtx.swatchCtx.expressCtx()).to.deep.equal(req.expressCtx);
-        done();
       }
-      middleware(req, res, next);
+
+      await middleware(req, res, next);
     });
   });
 });

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -6,11 +6,19 @@ const context = require('../lib/context');
 
 describe('context', () => {
   const req = {
+    get: (arg) => {
+      const headers = {
+        host: 'localhost:3123',
+        origin: 'localhost:3124',
+      };
+      return headers[arg];
+    },
     headers: { authorization: 'value' },
     method: 'GET',
+    originalUrl: '/some/path',
     path: 'some/path',
     protocol: 'http',
-    query: '?name=test',
+    query: { name: 'test' },
     secure: false,
   };
   const res = {};
@@ -28,11 +36,15 @@ describe('context', () => {
         expect(req.expressCtx).not.to.be.a('null');
 
         expect(req.expressCtx.swatchCtx.req.headers).to.deep.equal(req.headers);
+        expect(req.expressCtx.swatchCtx.req.href).to.deep.equal('http://localhost:3123/some/path');
+        expect(req.expressCtx.swatchCtx.req.host).to.deep.equal('localhost:3123');
         expect(req.expressCtx.swatchCtx.req.method).to.deep.equal('GET');
+        expect(req.expressCtx.swatchCtx.req.origin).to.deep.equal('localhost:3124');
         expect(req.expressCtx.swatchCtx.req.path).to.deep.equal('some/path');
         expect(req.expressCtx.swatchCtx.req.protocol).to.deep.equal('http');
-        expect(req.expressCtx.swatchCtx.req.query).to.deep.equal('?name=test');
+        expect(req.expressCtx.swatchCtx.req.query).to.deep.equal({ name: 'test' });
         expect(req.expressCtx.swatchCtx.req.secure).to.deep.equal(false);
+        expect(req.expressCtx.swatchCtx.req.url).to.deep.equal('some/path');
 
         // Make sure we can get the expressCtx from the swatchCtx
         expect(req.expressCtx.swatchCtx.expressCtx()).to.deep.equal(req.expressCtx);

--- a/test/middleware/logger.test.js
+++ b/test/middleware/logger.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const logger = require('../../lib/middleware/logger').default;
+const logger = require('../../lib/middleware/logger');
 
 describe('logger', () => {
   it('uses the expressCtx.log logger if available', async () => {

--- a/test/middleware/response.test.js
+++ b/test/middleware/response.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const response = require('../../lib/middleware/response').default;
+const response = require('../../lib/middleware/response');
 
 describe('response', () => {
   describe('error', () => {

--- a/test/validation.test.js
+++ b/test/validation.test.js
@@ -5,23 +5,25 @@ const validation = require('../lib/validation');
 describe('validation', () => {
   it('returns middleware which calls paramFn first, then validateFn', (done) => {
     const req = {
-      params: 'x',
+      params: { x: true },
       expressCtx: {
-        swatchCtx: {
-
-        },
+        swatchCtx: {},
       },
     };
     const res = undefined;
-    function validate(ctx, params) {
+
+    function validateFn(ctx, params) {
       expect(ctx).to.deep.equal(req.expressCtx);
       expect(params).to.deep.equal(req.params);
+
       done();
     }
 
-    function param(request) {
+    function paramFn(request) {
       return request.params;
     }
-    validation.middleware(validate, param)(req, res, () => Promise.resolve);
+
+    const middlewareFn = validation.middleware(validateFn, paramFn);
+    middlewareFn(req, res, () => Promise.resolve);
   });
 });


### PR DESCRIPTION
After starting on the PR to handle correlation IDs, I got distracted and wanted to build out this piece of the swatch-express functionality, where we set the swatch context properties from the request object.

I also noticed when I tried to run this end-to-end with the latest version of Express that it failed in a number of places, including unsupported imports/export statements and excess commas. Fixing those as a first step, I still think something is fishy here and not entirely sure this package works at all